### PR TITLE
Removed f-strings for downwards compatibility with Python <3.6

### DIFF
--- a/python/jmxquery/__init__.py
+++ b/python/jmxquery/__init__.py
@@ -149,7 +149,7 @@ class JMXConnection(object):
             queryString += query.to_query_string() + ";"
 
         command.extend(["-q", queryString])
-        logger.debug(f"Running command: {command}")
+        logger.debug("Running command: " + str(command))
 
         jsonOutput = "[]"
         try:
@@ -161,7 +161,7 @@ class JMXConnection(object):
 
             jsonOutput = output.stdout.decode('utf-8')
         except subprocess.TimeoutExpired as err:
-            logger.error(f"Error calling JMX, Timeout of {err.timeout} Expired: " + err.output.decode('utf-8'))
+            logger.error("Error calling JMX, Timeout of " + str(err.timeout) + " Expired: " + err.output.decode('utf-8'))
         except subprocess.CalledProcessError as err:
             logger.error("Error calling JMX: " + err.output.decode('utf-8'))
             raise err


### PR DESCRIPTION
For downwards compatibility with Python <3.6, I remove the fancy f-strings.
This fixes #6