### PR TITLE
Make json decoding not strict. JMX sometimes throws control characters

### DIFF
--- a/python/jmxquery/__init__.py
+++ b/python/jmxquery/__init__.py
@@ -25,6 +25,10 @@ class MetricType(Enum):
     COUNTER = 'counter'
     GAUGE = 'gauge'
 
+class NotStrictJSONDecoder(json.JSONDecoder):
+    def __init__(self, strict=False, *args, **kwargs):
+        json.JSONDecoder.__init__(self, strict=False, *args, **kwargs)
+
 class JMXQuery:
     """
     A JMX Query which is used to fetch specific MBean attributes/values from the JVM. The object_name can support wildcards
@@ -177,7 +181,7 @@ class JMXConnection(object):
         :param jsonOutput:  The JSON Array returned from the command line
         :return:            An array of JMXQuerys
         """
-        jsonMetrics = json.loads(jsonOutput)
+        jsonMetrics = json.loads(jsonOutput, cls=NotStrictJSONDecoder)
         metrics = []
         for jsonMetric in jsonMetrics:
             mBeanName = jsonMetric['mBeanName']


### PR DESCRIPTION
Hi. 

I was having an issue writing a script to monitor an application and trying to dump what I could monitor on that app due to JMX throwing JSON control characters in it's output. This should resolve that without breaking any backwards compatibility.

Thanks,
Matthew